### PR TITLE
Fixed SDK lookup procedure by replacing letters enumerating with usag…

### DIFF
--- a/prepareWebRtc.bat
+++ b/prepareWebRtc.bat
@@ -450,17 +450,11 @@ POPD
 GOTO:EOF
 
 :determineWindowsSDK
-SET windowsSDKPath="Program Files (x86)\Windows Kits\10\Lib\"
-SET windowsSDKFullPath=C:\!windowsSDKPath!
+SET windowsSDKFullPath="%ProgramFiles(x86)%\Windows Kits\10\Lib\"
 
 IF DEFINED USE_WIN_SDK_FULL_PATH SET windowsSDKFullPath=!USE_WIN_SDK_FULL_PATH! && GOTO parseSDKPath
 IF DEFINED USE_WIN_SDK SET windowsSDKVersion=!USE_WIN_SDK! && GOTO setVersion
-FOR %%p IN (A B C D E F G H I J K L M N O P Q R S T U V W X Y Z) DO (
-	IF EXIST %%p:\!windowsSDKPath! (
-		SET windowsSDKFullPath=%%p:\!windowsSDKPath!
-		GOTO determineVersion
-	)
-)
+
 
 :parseSDKPath
 IF EXIST !windowsSDKFullPath! (


### PR DESCRIPTION
…e of special environment variable to find Programs Files (x86) path.

When there is multiple systems installed on different drives, SDK lookup might find path from not currently running Windows. On my machine active windows is run on H: drive, but there are also installed system on C: drive, but the system on C: drive does not have properly configured SDK which confuses preparation script.

In my case this mysteriously results in the following preparation erro:

```
e:\Projects\github\webrtc-uwp\webrtc-uwp-sdk>bin\prepare.bat
Running script with default parameters:
Target: all (Ortc and WebRtc)
Platform: all (x64, x86, arm and win32)
Log level: 2 (warning)

Running prepare script ...

Preparing webRTC development environment ...
Preparing development environment for ARM, x64, x86 and win32 platforms ...

Running WebRTC prepare script ...
=================================
Preparing WebRTC development environment for arm, x64, x86 and win32 platforms ...
        1 file(s) copied.
        1 file(s) copied.
        1 file(s) copied.
        1 file(s) copied.
0> File buildtools\win\gn.exe exists and SHA1 matches. Skipping.
Success!
Downloading 1 files took 0.109000 second(s)
0> File buildtools\win\clang-format.exe exists and SHA1 matches. Skipping.
Success!
Downloading 1 files took 0.158000 second(s)

CRITICAL ERROR: Windows SDK is not fully installed. Debugger Tools are missing. Please install standalone Windows SDK version. You can download installer from this link https://developer.microsoft.com/de-de/windows/downloads/sdk-archive

FAILURE:Preparing WebRTC development environment has failed.
=======   WebRTC prepare script summary   =======
=======   platform   =========   result   =======
            arm                 not run
            x64                 not run
            x86                 not run
            win32               not run
=================================================
```